### PR TITLE
add location_session_path for SessionsClient

### DIFF
--- a/dialogflow_v2beta1/gapic/sessions_client.py
+++ b/dialogflow_v2beta1/gapic/sessions_client.py
@@ -109,6 +109,16 @@ class SessionsClient(object):
         )
 
     @classmethod
+    def location_session_path(cls, project, location, session):
+        """Return a fully-qualified location_session string."""
+        return google.api_core.path_template.expand(
+            "projects/{project}/locations/{location}/agent/sessions/{session}",
+            project=project,
+            location=location,
+            session=session,
+        )
+
+    @classmethod
     def session_path(cls, project, session):
         """Return a fully-qualified session string."""
         return google.api_core.path_template.expand(


### PR DESCRIPTION
## WHAT
Add location_session_path method for SessionsClient v2beta1.

## WHY
We need to set location in the case of requesting for non-US locations (e.g. asia-northeast1).
https://cloud.google.com/dialogflow/es/docs/how/region#api

I'm sure there are other paths developer will need, but in the meantime, let me add the path we need.