### PR TITLE
docs: raise DeprecationWarning when 'dialogflow' is installed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Dialogflow: Python Client
 
 
 
-    Python idiomatic client for `Dialogflow <https://dialogflow.com/`_
+    Python idiomatic client for `Dialogflow <https://dialogflow.com/>`_
 
 `Dialogflow <https://dialogflow.com/`_ is an enterprise-grade NLU platform that makes it easy for
 developers to design and integrate conversational user interfaces into

--- a/README.rst
+++ b/README.rst
@@ -16,9 +16,9 @@ Dialogflow: Python Client
 
 |release level|
 
-    Python idiomatic client for Dialogflow_
+    Python idiomatic client for `Dialogflow <https://dialogflow.com/`_
 
-Dialogflow_ is an enterprise-grade NLU platform that makes it easy for
+`Dialogflow <https://dialogflow.com/`_ is an enterprise-grade NLU platform that makes it easy for
 developers to design and integrate conversational user interfaces into
 mobile apps, web applications, devices, and bots.
 
@@ -29,8 +29,6 @@ mobile apps, web applications, devices, and bots.
 Read more about the client libraries for Cloud APIs, including the older
 Google APIs Client Libraries, in
 `Client Libraries Explained <https://cloud.google.com/apis/docs/client-libraries-explained>`_.
-
-.. _Dialogflow: https://dialogflow.com/
 
 
 Before you begin

--- a/README.rst
+++ b/README.rst
@@ -2,12 +2,12 @@ Dialogflow: Python Client
 =========================
 
 .. warning::
-    The package dialogflow_ has been renamed to google-cloud-dialogflow_.
-    dialogflow_ will no longer be updated.
+    The package `dialogflow`_ has been renamed to `google-cloud-dialogflow`_.
+    `dialogflow`_ will no longer be updated.
 
     For help upgrading to ``google-cloud-dialogflow>=2.0.0``, see the `Migration Guide`_.
 
-    After **October 20, 2021**, importing code from the latest release of dialogflow_ will result in a RuntimeError. If you need to continue to use dialogflow_ after this date, please pin to a specific version of dialogflow_ (e.g., ``dialogflow==1.1.1``). If you have questions, please `file an issue`_.
+    After **October 20, 2021**, importing code from the latest release of `dialogflow`_ will result in a ``RuntimeError``. If you need to continue to use `dialogflow`_ after this date, please pin to a specific version of `dialogflow`_ (e.g., ``dialogflow==1.1.1``). If you have questions, please `file an issue`_.
 
 .. _dialogflow: https://pypi.org/project/dialogflow
 .. _google-cloud-dialogflow: https://pypi.org/project/google-cloud-dialogflow

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Dialogflow: Python Client
 
     Python idiomatic client for `Dialogflow <https://dialogflow.com/>`_
 
-`Dialogflow <https://dialogflow.com/`_ is an enterprise-grade NLU platform that makes it easy for
+`Dialogflow <https://dialogflow.com/>`_ is an enterprise-grade NLU platform that makes it easy for
 developers to design and integrate conversational user interfaces into
 mobile apps, web applications, devices, and bots.
 

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,11 @@
 Dialogflow: Python Client
 =========================
 
+.. warning::
+    The package 'dialogflow' has been renamed to 'google-cloud-dialogflow'. 'dialogflow' will no longer be updated. For help upgrading to google-cloud-dialogflow>=2.0.0, see https://github.com/googleapis/python-dialogflow/blob/master/UPGRADING.md.
+
+    After **October 20, 2021**, importing code from the latest release of 'dialogflow' will result in a RuntimeError. If you need to continue to use 'dialogflow' after this date, please pin to a specific version of 'dialogflow' (e.g., dialogflow==1.1.1). If you have questions, please file an issue: https://github.com/googleapis/python-dialogflow/issues.
+
 |release level|
 
     Python idiomatic client for `Dialogflow`_

--- a/README.rst
+++ b/README.rst
@@ -1,20 +1,21 @@
 Dialogflow: Python Client
 =========================
 
+
 .. warning::
     The package `dialogflow`_ has been renamed to `google-cloud-dialogflow`_.
     `dialogflow`_ will no longer be updated.
 
     For help upgrading to ``google-cloud-dialogflow>=2.0.0``, see the `Migration Guide`_.
 
-    After **October 20, 2021**, importing code from the latest release of `dialogflow`_ will result in a ``RuntimeError``. If you need to continue to use `dialogflow`_ after this date, please pin to a specific version of `dialogflow`_ (e.g., ``dialogflow==1.1.1``). If you have questions, please `file an issue`_.
+    After **October 28, 2021**, importing code from the latest release of `dialogflow`_ will result in a ``RuntimeError``. If you need to continue to use `dialogflow`_ after this date, please pin to a specific version of `dialogflow`_ (e.g., ``dialogflow==1.1.1``). If you have questions, please `file an issue`_.
 
 .. _dialogflow: https://pypi.org/project/dialogflow
 .. _google-cloud-dialogflow: https://pypi.org/project/google-cloud-dialogflow
 .. _Migration Guide: https://github.com/googleapis/python-dialogflow/blob/master/UPGRADING.md
 .. _file an issue: https://github.com/googleapis/python-dialogflow/issues
 
-|release level|
+
 
     Python idiomatic client for `Dialogflow <https://dialogflow.com/`_
 

--- a/README.rst
+++ b/README.rst
@@ -2,22 +2,23 @@ Dialogflow: Python Client
 =========================
 
 .. warning::
-    The package `dialogflow`_ has been renamed to `google-cloud-dialogflow`_.
-    `dialogflow`_ will no longer be updated.
+    The package dialogflow_ has been renamed to google-cloud-dialogflow_.
+    dialogflow_ will no longer be updated.
 
-    For help upgrading to ``google-cloud-dialogflow>=2.0.0``, see the `Migration Guide <https://github.com/googleapis/python-dialogflow/blob/master/UPGRADING.md>`_.
+    For help upgrading to ``google-cloud-dialogflow>=2.0.0``, see the `Migration Guide`_.
 
-    After **October 20, 2021**, importing code from the latest release of `dialogflow`_ will result in a RuntimeError. If you need to continue to use `dialogflow`_ after this date, please pin to a specific version of `dialogflow`_ (e.g., ``dialogflow==1.1.1``). If you have questions, please `file an issue`_.
+    After **October 20, 2021**, importing code from the latest release of dialogflow_ will result in a RuntimeError. If you need to continue to use dialogflow_ after this date, please pin to a specific version of dialogflow_ (e.g., ``dialogflow==1.1.1``). If you have questions, please `file an issue`_.
 
 .. _dialogflow: https://pypi.org/project/dialogflow
 .. _google-cloud-dialogflow: https://pypi.org/project/google-cloud-dialogflow
+.. _Migration Guide: https://github.com/googleapis/python-dialogflow/blob/master/UPGRADING.md
 .. _file an issue: https://github.com/googleapis/python-dialogflow/issues
 
 |release level|
 
-    Python idiomatic client for `Dialogflow`_
+    Python idiomatic client for Dialogflow_
 
-`Dialogflow`_ is an enterprise-grade NLU platform that makes it easy for
+Dialogflow_ is an enterprise-grade NLU platform that makes it easy for
 developers to design and integrate conversational user interfaces into
 mobile apps, web applications, devices, and bots.
 

--- a/README.rst
+++ b/README.rst
@@ -2,9 +2,16 @@ Dialogflow: Python Client
 =========================
 
 .. warning::
-    The package 'dialogflow' has been renamed to 'google-cloud-dialogflow'. 'dialogflow' will no longer be updated. For help upgrading to google-cloud-dialogflow>=2.0.0, see https://github.com/googleapis/python-dialogflow/blob/master/UPGRADING.md.
+    The package `dialogflow`_ has been renamed to `google-cloud-dialogflow`_.
+    `dialogflow`_ will no longer be updated.
 
-    After **October 20, 2021**, importing code from the latest release of 'dialogflow' will result in a RuntimeError. If you need to continue to use 'dialogflow' after this date, please pin to a specific version of 'dialogflow' (e.g., dialogflow==1.1.1). If you have questions, please file an issue: https://github.com/googleapis/python-dialogflow/issues.
+    For help upgrading to ``google-cloud-dialogflow>=2.0.0``, see the `Migration Guide <https://github.com/googleapis/python-dialogflow/blob/master/UPGRADING.md>`_.
+
+    After **October 20, 2021**, importing code from the latest release of `dialogflow`_ will result in a RuntimeError. If you need to continue to use `dialogflow`_ after this date, please pin to a specific version of `dialogflow`_ (e.g., ``dialogflow==1.1.1``). If you have questions, please `file an issue`_.
+
+.. _dialogflow: https://pypi.org/project/dialogflow
+.. _google-cloud-dialogflow: https://pypi.org/project/google-cloud-dialogflow
+.. _file an issue: https://github.com/googleapis/python-dialogflow/issues
 
 |release level|
 

--- a/dialogflow_v2/__init__.py
+++ b/dialogflow_v2/__init__.py
@@ -38,6 +38,13 @@ if sys.version_info[:2] == (2, 7):
     )
     warnings.warn(message, DeprecationWarning)
 
+raise RuntimeError(
+    "'dialogflow' has been renamed to 'google-cloud-dialogflow'."
+    "'dialogflow' will no longer be updated."
+    "For help upgrading to gogole-cloud-dialogflow>=2.0.0, see"
+    "https://github.com/googleapis/python-dialogflow/blob/master/UPGRADING.md"
+)
+
 
 class AgentsClient(agents_client.AgentsClient):
     __doc__ = agents_client.AgentsClient.__doc__

--- a/dialogflow_v2/__init__.py
+++ b/dialogflow_v2/__init__.py
@@ -39,9 +39,9 @@ if sys.version_info[:2] == (2, 7):
     warnings.warn(message, DeprecationWarning)
 
 raise RuntimeError(
-    "'dialogflow' has been renamed to 'google-cloud-dialogflow'."
-    "'dialogflow' will no longer be updated."
-    "For help upgrading to gogole-cloud-dialogflow>=2.0.0, see"
+    "'dialogflow' has been renamed to 'google-cloud-dialogflow'. "
+    "'dialogflow' will no longer be updated. "
+    "For help upgrading to google-cloud-dialogflow>=2.0.0, see "
     "https://github.com/googleapis/python-dialogflow/blob/master/UPGRADING.md"
 )
 

--- a/dialogflow_v2/__init__.py
+++ b/dialogflow_v2/__init__.py
@@ -38,11 +38,21 @@ if sys.version_info[:2] == (2, 7):
     )
     warnings.warn(message, DeprecationWarning)
 
-raise RuntimeError(
-    "'dialogflow' has been renamed to 'google-cloud-dialogflow'. "
+package_deprecation_message = (
+    "The package 'dialogflow' has been renamed to 'google-cloud-dialogflow'. "
     "'dialogflow' will no longer be updated. "
-    "For help upgrading to google-cloud-dialogflow>=2.0.0, see "
-    "https://github.com/googleapis/python-dialogflow/blob/master/UPGRADING.md"
+    "For help upgrading to google-cloud-dialogflow>=2.0.0, "
+    "see https://github.com/googleapis/python-dialogflow/blob/master/UPGRADING.md. "
+    "\n\nAfter October 20, 2021, importing code from the latest release of 'dialogflow' "
+    "will result in a RuntimeError. If you need to continue to use 'dialogflow' after this date, "
+    "please pin to a specific version of 'dialogflow' (e.g., dialogflow==1.1.1). "
+    "If you have questions, please file an issue: "
+    "https://github.com/googleapis/python-dialogflow/issues."
+)
+
+warnings.warn(
+    package_deprecation_message,
+    DeprecationWarning
 )
 
 

--- a/dialogflow_v2/__init__.py
+++ b/dialogflow_v2/__init__.py
@@ -43,7 +43,7 @@ package_deprecation_message = (
     "'dialogflow' will no longer be updated. "
     "For help upgrading to google-cloud-dialogflow>=2.0.0, "
     "see https://github.com/googleapis/python-dialogflow/blob/master/UPGRADING.md. "
-    "\n\nAfter October 20, 2021, importing code from the latest release of 'dialogflow' "
+    "\n\nAfter October 28, 2021, importing code from the latest release of 'dialogflow' "
     "will result in a RuntimeError. If you need to continue to use 'dialogflow' after this date, "
     "please pin to a specific version of 'dialogflow' (e.g., dialogflow==1.1.1). "
     "If you have questions, please file an issue: "

--- a/dialogflow_v2beta1/__init__.py
+++ b/dialogflow_v2beta1/__init__.py
@@ -41,6 +41,13 @@ if sys.version_info[:2] == (2, 7):
     warnings.warn(message, DeprecationWarning)
 
 
+raise RuntimeError(
+    "'dialogflow' has been renamed to 'google-cloud-dialogflow'. "
+    "'dialogflow' will no longer be updated. "
+    "For help upgrading to google-cloud-dialogflow>=2.0.0, see "
+    "https://github.com/googleapis/python-dialogflow/blob/master/UPGRADING.md"
+)
+
 class EnvironmentsClient(environments_client.EnvironmentsClient):
     __doc__ = environments_client.EnvironmentsClient.__doc__
     enums = enums

--- a/dialogflow_v2beta1/__init__.py
+++ b/dialogflow_v2beta1/__init__.py
@@ -46,7 +46,7 @@ package_deprecation_message = (
     "'dialogflow' will no longer be updated. "
     "For help upgrading to google-cloud-dialogflow>=2.0.0, "
     "see https://github.com/googleapis/python-dialogflow/blob/master/UPGRADING.md. "
-    "\n\nAfter October 20, 2021, importing code from the latest release of 'dialogflow' "
+    "\n\nAfter October 28, 2021, importing code from the latest release of 'dialogflow' "
     "will result in a RuntimeError. If you need to continue to use 'dialogflow' after this date, "
     "please pin to a specific version of 'dialogflow' (e.g., dialogflow==1.1.1). "
     "If you have questions, please file an issue: "

--- a/dialogflow_v2beta1/__init__.py
+++ b/dialogflow_v2beta1/__init__.py
@@ -41,13 +41,22 @@ if sys.version_info[:2] == (2, 7):
     warnings.warn(message, DeprecationWarning)
 
 
-raise RuntimeError(
-    "'dialogflow' has been renamed to 'google-cloud-dialogflow'. "
+package_deprecation_message = (
+    "The package 'dialogflow' has been renamed to 'google-cloud-dialogflow'. "
     "'dialogflow' will no longer be updated. "
-    "For help upgrading to google-cloud-dialogflow>=2.0.0, see "
-    "https://github.com/googleapis/python-dialogflow/blob/master/UPGRADING.md"
+    "For help upgrading to google-cloud-dialogflow>=2.0.0, "
+    "see https://github.com/googleapis/python-dialogflow/blob/master/UPGRADING.md. "
+    "\n\nAfter October 20, 2021, importing code from the latest release of 'dialogflow' "
+    "will result in a RuntimeError. If you need to continue to use 'dialogflow' after this date, "
+    "please pin to a specific version of 'dialogflow' (e.g., dialogflow==1.1.1). "
+    "If you have questions, please file an issue: "
+    "https://github.com/googleapis/python-dialogflow/issues."
 )
 
+warnings.warn(
+    package_deprecation_message,
+    DeprecationWarning
+)
 class EnvironmentsClient(environments_client.EnvironmentsClient):
     __doc__ = environments_client.EnvironmentsClient.__doc__
     enums = enums

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ import setuptools
 
 name = "dialogflow"
 description = "Client library for the Dialogflow API"
-version = "1.1.0"
+version = "2.0.0"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = ["google-api-core[grpc] >= 1.14.0, < 2.0.0dev"]
 


### PR DESCRIPTION
Closes #243.

To be released manually as [`dialogflow`](https://pypi.org/project/dialogflow/) 1.1.1, to signal to remaining users that they should use the new package name [`google-cloud-dialogflow`](https://pypi.org/project/google-cloud-dialogflow/).

Attempting to import `dialogflow` results in a `Deprecationwarning`.
```
(env) busunkim@busunkim:~/github/python-dialogflow$ python3
Python 3.9.2 (default, Feb 28 2021, 17:03:44) 
[GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import warnings
>>> warnings.simplefilter('always')
>>> import dialogflow
/usr/local/google/home/busunkim/github/python-dialogflow/dialogflow_v2/__init__.py:53: DeprecationWarning: The package 'dialogflow' has been renamed to 'google-cloud-dialogflow'. 'dialogflow' will no longer be updated. For help upgrading to google-cloud-dialogflow>=2.0.0, see https://github.com/googleapis/python-dialogflow/blob/master/UPGRADING.md. 

After October 28, 2021, importing code from the latest release of 'dialogflow' will result in a RuntimeError. If you need to continue to use 'dialogflow' after this date, please pin to a specific version of 'dialogflow' (e.g., dialogflow==1.1.1). If you have questions, please file an issue: https://github.com/googleapis/python-dialogflow/issues.
```

On/after **October 28, 2021** an additional 2.0.0 `dialogflow` release will be made that raises a `RuntimeError` instead.

Googlers, see internal [doc](https://docs.google.com/document/d/1isYCZFM0zigFwOLzWdKWfc1TJkvOcAXaHlauzUpvY2M/edit#).