### PR TITLE
chore: prevent normalization of semver versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setuptools.setup(
     name="google-cloud-dialogflow",
     description=description,
     long_description=readme,
-    version=version,
+    version=setuptools.sic(version),
     author="Google LLC",
     author_email="googleapis-packages@google.com",
     license="Apache 2.0",

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,21 @@ import os
 
 import setuptools
 
+# Disable version normalization performed by setuptools.setup()
+try:
+    # Try the approach of using sic(), added in setuptools 46.1.0
+    from setuptools import sic
+except ImportError:
+    # Try the approach of replacing packaging.version.Version
+    sic = lambda v: v
+    try:
+        # setuptools >=39.0.0 uses packaging from setuptools.extern
+        from setuptools.extern import packaging
+    except ImportError:
+        # setuptools <39.0.0 uses packaging from pkg_resources.extern
+        from pkg_resources.extern import packaging
+    packaging.version.Version = packaging.version.LegacyVersion
+
 name = "dialogflow"
 description = "Client library for the Dialogflow API"
 version = "2.1.2"
@@ -35,7 +50,7 @@ setuptools.setup(
     name="google-cloud-dialogflow",
     description=description,
     long_description=readme,
-    version=setuptools.sic(version),
+    version=sic(version),
     author="Google LLC",
     author_email="googleapis-packages@google.com",
     license="Apache 2.0",


### PR DESCRIPTION
When there is a patch version added to semver versioning, setuptools.setup(version) will normalize the versioning from `-patch` to `.patch` which is not correct SEMVER versioning. The added feature with setuptools.sic(version) will prevent this from happening.