### PR TITLE
 chore: Update Owl bot `begin-after-commit-hash`

### DIFF
--- a/.github/.OwlBot.yaml
+++ b/.github/.OwlBot.yaml
@@ -22,5 +22,5 @@ deep-copy-regex:
   - source: /google/cloud/dialogflow/(v.*)/.*-py/(.*)
     dest: /owl-bot-staging/$1/$2
 
-begin-after-commit-hash: 89df06c8330f5a14049dccc2836bd28497df2247
+begin-after-commit-hash: 0a3c7d272d697796db75857bac73905c68e498c3
 


### PR DESCRIPTION
PR #290 included changes to the generated client but the conventional commit messages were not included in the PR. This PR updates the `begin-after-commit-hash` that owl-bot uses to pull changes from googleapis-gen to match [this commit](https://github.com/googleapis/googleapis-gen/search?q=0a3c7d272d697796db75857bac73905c68e498c3&type=commits).

The following changes are already in master:

feat: added more Environment RPCs
feat: added Versions service
feat: added Fulfillment service
feat: added TextToSpeechSettings.
feat: added location in some resource patterns
fix: removed incorrect resource annotation for UpdateEnvironmentRequest.
fix: add async client to %name_%version/init.py
chore: add autogenerated snippets
chore: remove auth, policy, and options from the reserved names list
feat: support self-signed JWT flow for service accounts
chore: enable GAPIC metadata generation
chore: sort subpackages in %namespace/%name/init.py
