### PR TITLE
chore: update doc page from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "dialogflow",
     "name_pretty": "Dialogflow",
     "product_documentation": "https://www.dialogflow.com/",
-    "client_documentation": "https://googleapis.dev/python/dialogflow/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/dialogflow/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/5300385",
     "release_level": "ga",
     "language": "python",


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages.