### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "dialogflow",
     "name_pretty": "Dialogflow",
     "product_documentation": "https://www.dialogflow.com/",
-    "client_documentation": "https://googleapis.dev/python/dialogflow/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/dialogflow/latest",
     "issue_tracker": "https://issuetracker.google.com/savedsearches/5300385",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Dialogflow: Python Client
 developers to design and integrate conversational user interfaces into
 mobile apps, web applications, devices, and bots.
 
-* `Dialogflow ES Python Client API Reference <https://googleapis.dev/python/dialogflow/latest/index.html>`_
+* `Dialogflow ES Python Client API Reference <https://cloud.google.com/python/docs/reference/dialogflow/latest/index.html>`_
 * `Dialogflow ES Documentation <https://cloud.google.com/dialogflow/es/docs>`_
 
 Read more about the client libraries for Cloud APIs, including the older
@@ -65,7 +65,7 @@ The last version of this library compatible with Python 2.7 is dialogflow==1.1.0
 Usage
 -----
 
-View `usage documentation <https://googleapis.dev/python/dialogflow/latest/index.html>`_.
+View `usage documentation <https://cloud.google.com/python/docs/reference/dialogflow/latest/index.html>`_.
 
 
 Versioning


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.