### PR TITLE
fix(deps): require google-api-core >= 1.31.5, >= 2.3.2 on v1 release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,22 @@
+on:
+  pull_request:
+    branches:
+      - v1
+name: docs
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.7"
+    - name: Install nox
+      run: |
+        python -m pip install --upgrade setuptools pip wheel
+        python -m pip install nox
+    - name: Run docs
+      run: |
+        nox -s docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,25 @@
+on:
+  pull_request:
+    branches:
+      - v1
+name: lint
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.7"
+    - name: Install nox
+      run: |
+        python -m pip install --upgrade setuptools pip wheel
+        python -m pip install nox
+    - name: Run lint
+      run: |
+        nox -s lint
+    - name: Run lint_setup_py
+      run: |
+        nox -s lint_setup_py

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,0 +1,57 @@
+on:
+  pull_request:
+    branches:
+      - v1
+name: unittest
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ['3.6', '3.7', '3.8']
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python }}
+    - name: Install nox
+      run: |
+        python -m pip install --upgrade setuptools pip wheel
+        python -m pip install nox
+    - name: Run unit tests
+      env:
+        COVERAGE_FILE: .coverage-${{ matrix.python }}
+      run: |
+        nox -s unit-${{ matrix.python }}
+    - name: Upload coverage results
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage-artifacts
+        path: .coverage-${{ matrix.python }}
+
+  cover:
+    runs-on: ubuntu-latest
+    needs:
+        - unit
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.7"
+    - name: Install coverage
+      run: |
+        python -m pip install --upgrade setuptools pip wheel
+        python -m pip install coverage
+    - name: Download coverage results
+      uses: actions/download-artifact@v3
+      with:
+        name: coverage-artifacts
+        path: .coverage-results/
+    - name: Report coverage results
+      run: |
+        coverage combine .coverage-results/.coverage*
+        coverage report --show-missing --fail-under=71

--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,9 @@ Dialogflow: Python Client
 
 
 
-    Python idiomatic client for `Google Cloud Dialogflow <https://dialogflow.com/>`_
+    Python idiomatic client for `Google Cloud Dialogflow <https://dialogflow.com/>`__
 
-`Google Cloud Dialogflow <https://dialogflow.com/>`_ is an enterprise-grade NLU platform that makes it easy for
+`Google Cloud Dialogflow <https://dialogflow.com/>`__ is an enterprise-grade NLU platform that makes it easy for
 developers to design and integrate conversational user interfaces into
 mobile apps, web applications, devices, and bots.
 

--- a/dialogflow_v2/__init__.py
+++ b/dialogflow_v2/__init__.py
@@ -50,10 +50,7 @@ package_deprecation_message = (
     "https://github.com/googleapis/python-dialogflow/issues."
 )
 
-warnings.warn(
-    package_deprecation_message,
-    DeprecationWarning
-)
+warnings.warn(package_deprecation_message, DeprecationWarning)
 
 
 class AgentsClient(agents_client.AgentsClient):

--- a/dialogflow_v2/gapic/session_entity_types_client.py
+++ b/dialogflow_v2/gapic/session_entity_types_client.py
@@ -191,8 +191,10 @@ class SessionEntityTypesClient(object):
                     )
                 self.transport = transport
         else:
-            self.transport = session_entity_types_grpc_transport.SessionEntityTypesGrpcTransport(
-                address=api_endpoint, channel=channel, credentials=credentials
+            self.transport = (
+                session_entity_types_grpc_transport.SessionEntityTypesGrpcTransport(
+                    address=api_endpoint, channel=channel, credentials=credentials
+                )
             )
 
         if client_info is None:

--- a/dialogflow_v2/proto/agent_pb2_grpc.py
+++ b/dialogflow_v2/proto/agent_pb2_grpc.py
@@ -15,8 +15,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
 class AgentsStub(object):
-    """Service for managing [Agents][google.cloud.dialogflow.v2.Agent].
-    """
+    """Service for managing [Agents][google.cloud.dialogflow.v2.Agent]."""
 
     def __init__(self, channel):
         """Constructor.
@@ -72,26 +71,22 @@ class AgentsStub(object):
 
 
 class AgentsServicer(object):
-    """Service for managing [Agents][google.cloud.dialogflow.v2.Agent].
-    """
+    """Service for managing [Agents][google.cloud.dialogflow.v2.Agent]."""
 
     def GetAgent(self, request, context):
-        """Retrieves the specified agent.
-        """
+        """Retrieves the specified agent."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def SetAgent(self, request, context):
-        """Creates/updates the specified agent.
-        """
+        """Creates/updates the specified agent."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteAgent(self, request, context):
-        """Deletes the specified agent.
-        """
+        """Deletes the specified agent."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
@@ -229,8 +224,7 @@ def add_AgentsServicer_to_server(servicer, server):
 
 # This class is part of an EXPERIMENTAL API.
 class Agents(object):
-    """Service for managing [Agents][google.cloud.dialogflow.v2.Agent].
-    """
+    """Service for managing [Agents][google.cloud.dialogflow.v2.Agent]."""
 
     @staticmethod
     def GetAgent(

--- a/dialogflow_v2/proto/context_pb2_grpc.py
+++ b/dialogflow_v2/proto/context_pb2_grpc.py
@@ -9,8 +9,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
 class ContextsStub(object):
-    """Service for managing [Contexts][google.cloud.dialogflow.v2.Context].
-    """
+    """Service for managing [Contexts][google.cloud.dialogflow.v2.Context]."""
 
     def __init__(self, channel):
         """Constructor.
@@ -51,19 +50,16 @@ class ContextsStub(object):
 
 
 class ContextsServicer(object):
-    """Service for managing [Contexts][google.cloud.dialogflow.v2.Context].
-    """
+    """Service for managing [Contexts][google.cloud.dialogflow.v2.Context]."""
 
     def ListContexts(self, request, context):
-        """Returns the list of all contexts in the specified session.
-        """
+        """Returns the list of all contexts in the specified session."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetContext(self, request, context):
-        """Retrieves the specified context.
-        """
+        """Retrieves the specified context."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
@@ -78,22 +74,19 @@ class ContextsServicer(object):
         raise NotImplementedError("Method not implemented!")
 
     def UpdateContext(self, request, context):
-        """Updates the specified context.
-        """
+        """Updates the specified context."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteContext(self, request, context):
-        """Deletes the specified context.
-        """
+        """Deletes the specified context."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteAllContexts(self, request, context):
-        """Deletes all active contexts in the specified session.
-        """
+        """Deletes all active contexts in the specified session."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
@@ -140,8 +133,7 @@ def add_ContextsServicer_to_server(servicer, server):
 
 # This class is part of an EXPERIMENTAL API.
 class Contexts(object):
-    """Service for managing [Contexts][google.cloud.dialogflow.v2.Context].
-    """
+    """Service for managing [Contexts][google.cloud.dialogflow.v2.Context]."""
 
     @staticmethod
     def ListContexts(

--- a/dialogflow_v2/proto/entity_type_pb2_grpc.py
+++ b/dialogflow_v2/proto/entity_type_pb2_grpc.py
@@ -12,8 +12,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
 class EntityTypesStub(object):
-    """Service for managing [EntityTypes][google.cloud.dialogflow.v2.EntityType].
-    """
+    """Service for managing [EntityTypes][google.cloud.dialogflow.v2.EntityType]."""
 
     def __init__(self, channel):
         """Constructor.
@@ -74,40 +73,34 @@ class EntityTypesStub(object):
 
 
 class EntityTypesServicer(object):
-    """Service for managing [EntityTypes][google.cloud.dialogflow.v2.EntityType].
-    """
+    """Service for managing [EntityTypes][google.cloud.dialogflow.v2.EntityType]."""
 
     def ListEntityTypes(self, request, context):
-        """Returns the list of all entity types in the specified agent.
-        """
+        """Returns the list of all entity types in the specified agent."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetEntityType(self, request, context):
-        """Retrieves the specified entity type.
-        """
+        """Retrieves the specified entity type."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def CreateEntityType(self, request, context):
-        """Creates an entity type in the specified agent.
-        """
+        """Creates an entity type in the specified agent."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def UpdateEntityType(self, request, context):
-        """Updates the specified entity type.
-        """
+        """Updates the specified entity type."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteEntityType(self, request, context):
-        """Deletes the specified entity type.
-        """
+        """Deletes the specified entity type."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
@@ -223,8 +216,7 @@ def add_EntityTypesServicer_to_server(servicer, server):
 
 # This class is part of an EXPERIMENTAL API.
 class EntityTypes(object):
-    """Service for managing [EntityTypes][google.cloud.dialogflow.v2.EntityType].
-    """
+    """Service for managing [EntityTypes][google.cloud.dialogflow.v2.EntityType]."""
 
     @staticmethod
     def ListEntityTypes(

--- a/dialogflow_v2/proto/environment_pb2_grpc.py
+++ b/dialogflow_v2/proto/environment_pb2_grpc.py
@@ -8,8 +8,7 @@ from dialogflow_v2.proto import (
 
 
 class EnvironmentsStub(object):
-    """Service for managing [Environments][google.cloud.dialogflow.v2.Environment].
-    """
+    """Service for managing [Environments][google.cloud.dialogflow.v2.Environment]."""
 
     def __init__(self, channel):
         """Constructor.
@@ -25,12 +24,10 @@ class EnvironmentsStub(object):
 
 
 class EnvironmentsServicer(object):
-    """Service for managing [Environments][google.cloud.dialogflow.v2.Environment].
-    """
+    """Service for managing [Environments][google.cloud.dialogflow.v2.Environment]."""
 
     def ListEnvironments(self, request, context):
-        """Returns the list of all non-draft environments of the specified agent.
-        """
+        """Returns the list of all non-draft environments of the specified agent."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
@@ -52,8 +49,7 @@ def add_EnvironmentsServicer_to_server(servicer, server):
 
 # This class is part of an EXPERIMENTAL API.
 class Environments(object):
-    """Service for managing [Environments][google.cloud.dialogflow.v2.Environment].
-    """
+    """Service for managing [Environments][google.cloud.dialogflow.v2.Environment]."""
 
     @staticmethod
     def ListEnvironments(

--- a/dialogflow_v2/proto/intent_pb2_grpc.py
+++ b/dialogflow_v2/proto/intent_pb2_grpc.py
@@ -13,8 +13,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
 class IntentsStub(object):
-    """Service for managing [Intents][google.cloud.dialogflow.v2.Intent].
-    """
+    """Service for managing [Intents][google.cloud.dialogflow.v2.Intent]."""
 
     def __init__(self, channel):
         """Constructor.
@@ -60,40 +59,34 @@ class IntentsStub(object):
 
 
 class IntentsServicer(object):
-    """Service for managing [Intents][google.cloud.dialogflow.v2.Intent].
-    """
+    """Service for managing [Intents][google.cloud.dialogflow.v2.Intent]."""
 
     def ListIntents(self, request, context):
-        """Returns the list of all intents in the specified agent.
-        """
+        """Returns the list of all intents in the specified agent."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetIntent(self, request, context):
-        """Retrieves the specified intent.
-        """
+        """Retrieves the specified intent."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def CreateIntent(self, request, context):
-        """Creates an intent in the specified agent.
-        """
+        """Creates an intent in the specified agent."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def UpdateIntent(self, request, context):
-        """Updates the specified intent.
-        """
+        """Updates the specified intent."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteIntent(self, request, context):
-        """Deletes the specified intent and its direct or indirect followup intents.
-        """
+        """Deletes the specified intent and its direct or indirect followup intents."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
@@ -163,8 +156,7 @@ def add_IntentsServicer_to_server(servicer, server):
 
 # This class is part of an EXPERIMENTAL API.
 class Intents(object):
-    """Service for managing [Intents][google.cloud.dialogflow.v2.Intent].
-    """
+    """Service for managing [Intents][google.cloud.dialogflow.v2.Intent]."""
 
     @staticmethod
     def ListIntents(

--- a/dialogflow_v2/proto/session_entity_type_pb2_grpc.py
+++ b/dialogflow_v2/proto/session_entity_type_pb2_grpc.py
@@ -9,8 +9,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
 class SessionEntityTypesStub(object):
-    """Service for managing [SessionEntityTypes][google.cloud.dialogflow.v2.SessionEntityType].
-    """
+    """Service for managing [SessionEntityTypes][google.cloud.dialogflow.v2.SessionEntityType]."""
 
     def __init__(self, channel):
         """Constructor.
@@ -46,8 +45,7 @@ class SessionEntityTypesStub(object):
 
 
 class SessionEntityTypesServicer(object):
-    """Service for managing [SessionEntityTypes][google.cloud.dialogflow.v2.SessionEntityType].
-    """
+    """Service for managing [SessionEntityTypes][google.cloud.dialogflow.v2.SessionEntityType]."""
 
     def ListSessionEntityTypes(self, request, context):
         """Returns the list of all session entity types in the specified session.
@@ -144,8 +142,7 @@ def add_SessionEntityTypesServicer_to_server(servicer, server):
 
 # This class is part of an EXPERIMENTAL API.
 class SessionEntityTypes(object):
-    """Service for managing [SessionEntityTypes][google.cloud.dialogflow.v2.SessionEntityType].
-    """
+    """Service for managing [SessionEntityTypes][google.cloud.dialogflow.v2.SessionEntityType]."""
 
     @staticmethod
     def ListSessionEntityTypes(

--- a/dialogflow_v2beta1/__init__.py
+++ b/dialogflow_v2beta1/__init__.py
@@ -53,10 +53,9 @@ package_deprecation_message = (
     "https://github.com/googleapis/python-dialogflow/issues."
 )
 
-warnings.warn(
-    package_deprecation_message,
-    DeprecationWarning
-)
+warnings.warn(package_deprecation_message, DeprecationWarning)
+
+
 class EnvironmentsClient(environments_client.EnvironmentsClient):
     __doc__ = environments_client.EnvironmentsClient.__doc__
     enums = enums

--- a/dialogflow_v2beta1/gapic/session_entity_types_client.py
+++ b/dialogflow_v2beta1/gapic/session_entity_types_client.py
@@ -221,8 +221,10 @@ class SessionEntityTypesClient(object):
                     )
                 self.transport = transport
         else:
-            self.transport = session_entity_types_grpc_transport.SessionEntityTypesGrpcTransport(
-                address=api_endpoint, channel=channel, credentials=credentials
+            self.transport = (
+                session_entity_types_grpc_transport.SessionEntityTypesGrpcTransport(
+                    address=api_endpoint, channel=channel, credentials=credentials
+                )
             )
 
         if client_info is None:

--- a/dialogflow_v2beta1/proto/agent_pb2_grpc.py
+++ b/dialogflow_v2beta1/proto/agent_pb2_grpc.py
@@ -15,8 +15,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
 class AgentsStub(object):
-    """Service for managing [Agents][google.cloud.dialogflow.v2beta1.Agent].
-    """
+    """Service for managing [Agents][google.cloud.dialogflow.v2beta1.Agent]."""
 
     def __init__(self, channel):
         """Constructor.
@@ -72,26 +71,22 @@ class AgentsStub(object):
 
 
 class AgentsServicer(object):
-    """Service for managing [Agents][google.cloud.dialogflow.v2beta1.Agent].
-    """
+    """Service for managing [Agents][google.cloud.dialogflow.v2beta1.Agent]."""
 
     def GetAgent(self, request, context):
-        """Retrieves the specified agent.
-        """
+        """Retrieves the specified agent."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def SetAgent(self, request, context):
-        """Creates/updates the specified agent.
-        """
+        """Creates/updates the specified agent."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteAgent(self, request, context):
-        """Deletes the specified agent.
-        """
+        """Deletes the specified agent."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
@@ -232,8 +227,7 @@ def add_AgentsServicer_to_server(servicer, server):
 
 # This class is part of an EXPERIMENTAL API.
 class Agents(object):
-    """Service for managing [Agents][google.cloud.dialogflow.v2beta1.Agent].
-    """
+    """Service for managing [Agents][google.cloud.dialogflow.v2beta1.Agent]."""
 
     @staticmethod
     def GetAgent(

--- a/dialogflow_v2beta1/proto/context_pb2_grpc.py
+++ b/dialogflow_v2beta1/proto/context_pb2_grpc.py
@@ -9,8 +9,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
 class ContextsStub(object):
-    """Service for managing [Contexts][google.cloud.dialogflow.v2beta1.Context].
-    """
+    """Service for managing [Contexts][google.cloud.dialogflow.v2beta1.Context]."""
 
     def __init__(self, channel):
         """Constructor.
@@ -51,19 +50,16 @@ class ContextsStub(object):
 
 
 class ContextsServicer(object):
-    """Service for managing [Contexts][google.cloud.dialogflow.v2beta1.Context].
-    """
+    """Service for managing [Contexts][google.cloud.dialogflow.v2beta1.Context]."""
 
     def ListContexts(self, request, context):
-        """Returns the list of all contexts in the specified session.
-        """
+        """Returns the list of all contexts in the specified session."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetContext(self, request, context):
-        """Retrieves the specified context.
-        """
+        """Retrieves the specified context."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
@@ -78,22 +74,19 @@ class ContextsServicer(object):
         raise NotImplementedError("Method not implemented!")
 
     def UpdateContext(self, request, context):
-        """Updates the specified context.
-        """
+        """Updates the specified context."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteContext(self, request, context):
-        """Deletes the specified context.
-        """
+        """Deletes the specified context."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteAllContexts(self, request, context):
-        """Deletes all active contexts in the specified session.
-        """
+        """Deletes all active contexts in the specified session."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
@@ -140,8 +133,7 @@ def add_ContextsServicer_to_server(servicer, server):
 
 # This class is part of an EXPERIMENTAL API.
 class Contexts(object):
-    """Service for managing [Contexts][google.cloud.dialogflow.v2beta1.Context].
-    """
+    """Service for managing [Contexts][google.cloud.dialogflow.v2beta1.Context]."""
 
     @staticmethod
     def ListContexts(

--- a/dialogflow_v2beta1/proto/document_pb2_grpc.py
+++ b/dialogflow_v2beta1/proto/document_pb2_grpc.py
@@ -11,8 +11,7 @@ from google.longrunning import (
 
 
 class DocumentsStub(object):
-    """Service for managing knowledge [Documents][google.cloud.dialogflow.v2beta1.Document].
-    """
+    """Service for managing knowledge [Documents][google.cloud.dialogflow.v2beta1.Document]."""
 
     def __init__(self, channel):
         """Constructor.
@@ -53,8 +52,7 @@ class DocumentsStub(object):
 
 
 class DocumentsServicer(object):
-    """Service for managing knowledge [Documents][google.cloud.dialogflow.v2beta1.Document].
-    """
+    """Service for managing knowledge [Documents][google.cloud.dialogflow.v2beta1.Document]."""
 
     def ListDocuments(self, request, context):
         """Returns the list of all documents of the knowledge base.
@@ -161,8 +159,7 @@ def add_DocumentsServicer_to_server(servicer, server):
 
 # This class is part of an EXPERIMENTAL API.
 class Documents(object):
-    """Service for managing knowledge [Documents][google.cloud.dialogflow.v2beta1.Document].
-    """
+    """Service for managing knowledge [Documents][google.cloud.dialogflow.v2beta1.Document]."""
 
     @staticmethod
     def ListDocuments(

--- a/dialogflow_v2beta1/proto/entity_type_pb2_grpc.py
+++ b/dialogflow_v2beta1/proto/entity_type_pb2_grpc.py
@@ -12,8 +12,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
 class EntityTypesStub(object):
-    """Service for managing [EntityTypes][google.cloud.dialogflow.v2beta1.EntityType].
-    """
+    """Service for managing [EntityTypes][google.cloud.dialogflow.v2beta1.EntityType]."""
 
     def __init__(self, channel):
         """Constructor.
@@ -74,40 +73,34 @@ class EntityTypesStub(object):
 
 
 class EntityTypesServicer(object):
-    """Service for managing [EntityTypes][google.cloud.dialogflow.v2beta1.EntityType].
-    """
+    """Service for managing [EntityTypes][google.cloud.dialogflow.v2beta1.EntityType]."""
 
     def ListEntityTypes(self, request, context):
-        """Returns the list of all entity types in the specified agent.
-        """
+        """Returns the list of all entity types in the specified agent."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetEntityType(self, request, context):
-        """Retrieves the specified entity type.
-        """
+        """Retrieves the specified entity type."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def CreateEntityType(self, request, context):
-        """Creates an entity type in the specified agent.
-        """
+        """Creates an entity type in the specified agent."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def UpdateEntityType(self, request, context):
-        """Updates the specified entity type.
-        """
+        """Updates the specified entity type."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteEntityType(self, request, context):
-        """Deletes the specified entity type.
-        """
+        """Deletes the specified entity type."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
@@ -219,8 +212,7 @@ def add_EntityTypesServicer_to_server(servicer, server):
 
 # This class is part of an EXPERIMENTAL API.
 class EntityTypes(object):
-    """Service for managing [EntityTypes][google.cloud.dialogflow.v2beta1.EntityType].
-    """
+    """Service for managing [EntityTypes][google.cloud.dialogflow.v2beta1.EntityType]."""
 
     @staticmethod
     def ListEntityTypes(

--- a/dialogflow_v2beta1/proto/environment_pb2_grpc.py
+++ b/dialogflow_v2beta1/proto/environment_pb2_grpc.py
@@ -8,8 +8,7 @@ from dialogflow_v2beta1.proto import (
 
 
 class EnvironmentsStub(object):
-    """Service for managing [Environments][google.cloud.dialogflow.v2beta1.Environment].
-    """
+    """Service for managing [Environments][google.cloud.dialogflow.v2beta1.Environment]."""
 
     def __init__(self, channel):
         """Constructor.
@@ -25,12 +24,10 @@ class EnvironmentsStub(object):
 
 
 class EnvironmentsServicer(object):
-    """Service for managing [Environments][google.cloud.dialogflow.v2beta1.Environment].
-    """
+    """Service for managing [Environments][google.cloud.dialogflow.v2beta1.Environment]."""
 
     def ListEnvironments(self, request, context):
-        """Returns the list of all non-draft environments of the specified agent.
-        """
+        """Returns the list of all non-draft environments of the specified agent."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
@@ -52,8 +49,7 @@ def add_EnvironmentsServicer_to_server(servicer, server):
 
 # This class is part of an EXPERIMENTAL API.
 class Environments(object):
-    """Service for managing [Environments][google.cloud.dialogflow.v2beta1.Environment].
-    """
+    """Service for managing [Environments][google.cloud.dialogflow.v2beta1.Environment]."""
 
     @staticmethod
     def ListEnvironments(

--- a/dialogflow_v2beta1/proto/intent_pb2_grpc.py
+++ b/dialogflow_v2beta1/proto/intent_pb2_grpc.py
@@ -13,8 +13,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
 class IntentsStub(object):
-    """Service for managing [Intents][google.cloud.dialogflow.v2beta1.Intent].
-    """
+    """Service for managing [Intents][google.cloud.dialogflow.v2beta1.Intent]."""
 
     def __init__(self, channel):
         """Constructor.
@@ -60,40 +59,34 @@ class IntentsStub(object):
 
 
 class IntentsServicer(object):
-    """Service for managing [Intents][google.cloud.dialogflow.v2beta1.Intent].
-    """
+    """Service for managing [Intents][google.cloud.dialogflow.v2beta1.Intent]."""
 
     def ListIntents(self, request, context):
-        """Returns the list of all intents in the specified agent.
-        """
+        """Returns the list of all intents in the specified agent."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def GetIntent(self, request, context):
-        """Retrieves the specified intent.
-        """
+        """Retrieves the specified intent."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def CreateIntent(self, request, context):
-        """Creates an intent in the specified agent.
-        """
+        """Creates an intent in the specified agent."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def UpdateIntent(self, request, context):
-        """Updates the specified intent.
-        """
+        """Updates the specified intent."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
 
     def DeleteIntent(self, request, context):
-        """Deletes the specified intent and its direct or indirect followup intents.
-        """
+        """Deletes the specified intent and its direct or indirect followup intents."""
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")
         raise NotImplementedError("Method not implemented!")
@@ -163,8 +156,7 @@ def add_IntentsServicer_to_server(servicer, server):
 
 # This class is part of an EXPERIMENTAL API.
 class Intents(object):
-    """Service for managing [Intents][google.cloud.dialogflow.v2beta1.Intent].
-    """
+    """Service for managing [Intents][google.cloud.dialogflow.v2beta1.Intent]."""
 
     @staticmethod
     def ListIntents(

--- a/dialogflow_v2beta1/proto/knowledge_base_pb2_grpc.py
+++ b/dialogflow_v2beta1/proto/knowledge_base_pb2_grpc.py
@@ -9,8 +9,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
 class KnowledgeBasesStub(object):
-    """Service for managing [KnowledgeBases][google.cloud.dialogflow.v2beta1.KnowledgeBase].
-    """
+    """Service for managing [KnowledgeBases][google.cloud.dialogflow.v2beta1.KnowledgeBase]."""
 
     def __init__(self, channel):
         """Constructor.
@@ -46,8 +45,7 @@ class KnowledgeBasesStub(object):
 
 
 class KnowledgeBasesServicer(object):
-    """Service for managing [KnowledgeBases][google.cloud.dialogflow.v2beta1.KnowledgeBase].
-    """
+    """Service for managing [KnowledgeBases][google.cloud.dialogflow.v2beta1.KnowledgeBase]."""
 
     def ListKnowledgeBases(self, request, context):
         """Returns the list of all knowledge bases of the specified agent.
@@ -136,8 +134,7 @@ def add_KnowledgeBasesServicer_to_server(servicer, server):
 
 # This class is part of an EXPERIMENTAL API.
 class KnowledgeBases(object):
-    """Service for managing [KnowledgeBases][google.cloud.dialogflow.v2beta1.KnowledgeBase].
-    """
+    """Service for managing [KnowledgeBases][google.cloud.dialogflow.v2beta1.KnowledgeBase]."""
 
     @staticmethod
     def ListKnowledgeBases(

--- a/dialogflow_v2beta1/proto/session_entity_type_pb2_grpc.py
+++ b/dialogflow_v2beta1/proto/session_entity_type_pb2_grpc.py
@@ -9,8 +9,7 @@ from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
 class SessionEntityTypesStub(object):
-    """Service for managing [SessionEntityTypes][google.cloud.dialogflow.v2beta1.SessionEntityType].
-    """
+    """Service for managing [SessionEntityTypes][google.cloud.dialogflow.v2beta1.SessionEntityType]."""
 
     def __init__(self, channel):
         """Constructor.
@@ -46,8 +45,7 @@ class SessionEntityTypesStub(object):
 
 
 class SessionEntityTypesServicer(object):
-    """Service for managing [SessionEntityTypes][google.cloud.dialogflow.v2beta1.SessionEntityType].
-    """
+    """Service for managing [SessionEntityTypes][google.cloud.dialogflow.v2beta1.SessionEntityType]."""
 
     def ListSessionEntityTypes(self, request, context):
         """Returns the list of all session entity types in the specified session.
@@ -144,8 +142,7 @@ def add_SessionEntityTypesServicer_to_server(servicer, server):
 
 # This class is part of an EXPERIMENTAL API.
 class SessionEntityTypes(object):
-    """Service for managing [SessionEntityTypes][google.cloud.dialogflow.v2beta1.SessionEntityType].
-    """
+    """Service for managing [SessionEntityTypes][google.cloud.dialogflow.v2beta1.SessionEntityType]."""
 
     @staticmethod
     def ListSessionEntityTypes(

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,9 +65,9 @@ source_suffix = [".rst", ".md"]
 master_doc = "index"
 
 # General information about the project.
-project = u"dialogflow"
-copyright = u"2019, Google"
-author = u"Google APIs"
+project = "dialogflow"
+copyright = "2019, Google"
+author = "Google APIs"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -258,7 +258,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "dialogflow.tex", u"dialogflow Documentation", author, "manual")
+    (master_doc, "dialogflow.tex", "dialogflow Documentation", author, "manual")
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -286,7 +286,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "dialogflow", u"dialogflow Documentation", [author], 1)]
+man_pages = [(master_doc, "dialogflow", "dialogflow Documentation", [author], 1)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -301,7 +301,7 @@ texinfo_documents = [
     (
         master_doc,
         "dialogflow",
-        u"dialogflow Documentation",
+        "dialogflow Documentation",
         author,
         "dialogflow",
         "dialogflow Library",

--- a/noxfile.py
+++ b/noxfile.py
@@ -41,7 +41,7 @@ def lint(session):
     session.run("flake8", "dialogflow", "dialogflow_v2", "dialogflow_v2beta1")
 
 
-@nox.session(python="3.6")
+@nox.session(python="3.7")
 def blacken(session):
     """Run black.
     Format code to uniform standard.

--- a/noxfile.py
+++ b/noxfile.py
@@ -18,7 +18,7 @@ import shutil
 
 import nox
 
-BLACK_VERSION = "black==19.3b0"
+BLACK_VERSION = "black==22.3.0"
 BLACK_PATHS = [
     "dialogflow",
     "dialogflow_v2",
@@ -28,9 +28,13 @@ BLACK_PATHS = [
     "noxfile.py",
     "setup.py",
 ]
+DEFAULT_PYTHON_VERSION = "3.8"
+
+# Error if a python version is missing
+nox.options.error_on_missing_interpreters = True
 
 
-@nox.session(python="3.7")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def lint(session):
     """Run linters.
     Returns a failure if the linters find linting errors or sufficiently
@@ -41,7 +45,7 @@ def lint(session):
     session.run("flake8", "dialogflow", "dialogflow_v2", "dialogflow_v2beta1")
 
 
-@nox.session(python="3.7")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def blacken(session):
     """Run black.
     Format code to uniform standard.
@@ -53,7 +57,7 @@ def blacken(session):
     session.run("black", *BLACK_PATHS)
 
 
-@nox.session(python="3.7")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""
     session.install("docutils", "pygments")
@@ -86,7 +90,7 @@ def unit(session):
     default(session)
 
 
-@nox.session(python="3.7")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def cover(session):
     """Run the final coverage report.
     This outputs the coverage report aggregating coverage from the unit
@@ -98,12 +102,12 @@ def cover(session):
     session.run("coverage", "erase")
 
 
-@nox.session(python="3.7")
+@nox.session(python=DEFAULT_PYTHON_VERSION)
 def docs(session):
     """Build the docs for this library."""
 
     session.install("-e", ".")
-    session.install("sphinx<3.0.0", "alabaster", "recommonmark")
+    session.install("sphinx<3.0.0", "jinja2<3.1", "alabaster", "recommonmark")
 
     shutil.rmtree(os.path.join("docs", "_build"), ignore_errors=True)
     session.run(

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,9 @@ name = "dialogflow"
 description = "Client library for the Dialogflow API"
 version = "1.1.0"
 release_status = "Development Status :: 5 - Production/Stable"
-dependencies = ["google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",]
+dependencies = [
+    "google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0"
+]
 
 package_root = os.path.abspath(os.path.dirname(__file__))
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ name = "dialogflow"
 description = "Client library for the Dialogflow API"
 version = "1.1.0"
 release_status = "Development Status :: 5 - Production/Stable"
-dependencies = ["google-api-core[grpc] >= 1.14.0, < 2.0.0dev"]
+dependencies = ["google-api-core[grpc] >= 1.31.5, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0",]
 
 package_root = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
Allow google-api-core<3.0.0dev on previous release of library. Note that this PR is to a new protected branch **v1**, not **main**.

This will be followed by a release PR and is a step towards removing https://github.com/googleapis/google-cloud-python/issues/10566