### PR TITLE
docs: fix changelog header to consistent size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,7 +115,7 @@
 * **v2beta1:** recommend AnalyzeContent for future users ([#420](https://www.github.com/googleapis/python-dialogflow/issues/420)) ([1afdab3](https://www.github.com/googleapis/python-dialogflow/commit/1afdab3b50c98cc082b150ff408d0f07f11f9cf3))
 * **v2:** recommend AnalyzeContent for future users ([#421](https://www.github.com/googleapis/python-dialogflow/issues/421)) ([c6940a9](https://www.github.com/googleapis/python-dialogflow/commit/c6940a9f974af95037616bd1affb34d8db4405c9))
 
-### [2.9.1](https://www.github.com/googleapis/python-dialogflow/compare/v2.9.0...v2.9.1) (2021-10-04)
+## [2.9.1](https://www.github.com/googleapis/python-dialogflow/compare/v2.9.0...v2.9.1) (2021-10-04)
 
 
 ### Documentation
@@ -139,7 +139,7 @@
 
 * **samples:** added webhook code snippet ([#401](https://www.github.com/googleapis/python-dialogflow/issues/401)) ([9e279c8](https://www.github.com/googleapis/python-dialogflow/commit/9e279c86136543432cc218c2b1876bbb96f24240))
 
-### [2.8.1](https://www.github.com/googleapis/python-dialogflow/compare/v2.8.0...v2.8.1) (2021-09-29)
+## [2.8.1](https://www.github.com/googleapis/python-dialogflow/compare/v2.8.0...v2.8.1) (2021-09-29)
 
 
 ### Bug Fixes
@@ -168,7 +168,7 @@
 * update environment docs ([ad896f7](https://www.github.com/googleapis/python-dialogflow/commit/ad896f7401feb3f38b57612cb1bb865f1d3fc371))
 * update intent docs ([ad896f7](https://www.github.com/googleapis/python-dialogflow/commit/ad896f7401feb3f38b57612cb1bb865f1d3fc371))
 
-### [2.7.1](https://www.github.com/googleapis/python-dialogflow/compare/v2.7.0...v2.7.1) (2021-07-26)
+## [2.7.1](https://www.github.com/googleapis/python-dialogflow/compare/v2.7.0...v2.7.1) (2021-07-26)
 
 
 ### Bug Fixes
@@ -254,14 +254,14 @@
 * **deps:** add packaging requirement ([#293](https://www.github.com/googleapis/python-dialogflow/issues/293)) ([a9f970c](https://www.github.com/googleapis/python-dialogflow/commit/a9f970c98e62c362f8aa71c26b14d68eaeccbbbd))
 * removed incorrect resource annotation for UpdateEnvironmentRequest. ([1b39fc0](https://www.github.com/googleapis/python-dialogflow/commit/1b39fc00108af7b00cd8fbc3975a2bcf403b5749))
 
-### [2.1.2](https://www.github.com/googleapis/python-dialogflow/compare/v2.1.1...v2.1.2) (2021-04-13)
+## [2.1.2](https://www.github.com/googleapis/python-dialogflow/compare/v2.1.1...v2.1.2) (2021-04-13)
 
 
 ### Bug Fixes
 
 * remove unused proto InputText, InputAudio ([#273](https://www.github.com/googleapis/python-dialogflow/issues/273)) ([787d064](https://www.github.com/googleapis/python-dialogflow/commit/787d0648a842b62bfc1be8dcf43c0e8cbd88618a))
 
-### [2.1.1](https://www.github.com/googleapis/python-dialogflow/compare/v2.1.0...v2.1.1) (2021-04-12)
+## [2.1.1](https://www.github.com/googleapis/python-dialogflow/compare/v2.1.0...v2.1.1) (2021-04-12)
 
 
 ### Bug Fixes
@@ -339,14 +339,14 @@
 * **dialogflow:** add `MediaContent`,  `BrowseCarouselCard`, `ColumnProperties`in v2; add `SpeechContext`, `SpeechWordInfo`in v2; add `enable_word_info`, `speech_contexts`,`model` to InputAudioConfig in v2; add `subtitles` to `Intent.Message.ListSelect` in `v2beta1`; add `language_code` to `ListKnowledgeBase` in v2beta1; add `webhook_headers` to `QueryParameters` in v2beta1 ([#175](https://www.github.com/googleapis/dialogflow-python-client-v2/issues/175)) ([713846b](https://www.github.com/googleapis/dialogflow-python-client-v2/commit/713846b7ed99eaf78cdf383aa9d39b43731b9a0d))
 * add validation support to v2; add `output_audio_config_mask` to `detect_intent` method in v2beta1 and v2; add sub agent to v2beta1 (via synth) ([#179](https://www.github.com/googleapis/dialogflow-python-client-v2/issues/179)) ([5a6f18e](https://www.github.com/googleapis/dialogflow-python-client-v2/commit/5a6f18e362b5dd87affbe75e0d0bfc0c21ab87a9))
 
-### [0.7.2](https://www.github.com/googleapis/dialogflow-python-client-v2/compare/v0.7.1...v0.7.2) (2019-10-18)
+## [0.7.2](https://www.github.com/googleapis/dialogflow-python-client-v2/compare/v0.7.1...v0.7.2) (2019-10-18)
 
 
 ### Bug Fixes
 
 * define version once in setup.py ([#158](https://www.github.com/googleapis/dialogflow-python-client-v2/issues/158)) ([bf42fc4](https://www.github.com/googleapis/dialogflow-python-client-v2/commit/bf42fc45607b97bc040cbdacbde8ff5a4b6ad29b))
 
-### [0.7.1](https://www.github.com/googleapis/dialogflow-python-client-v2/compare/v0.7.0...v0.7.1) (2019-10-17)
+## [0.7.1](https://www.github.com/googleapis/dialogflow-python-client-v2/compare/v0.7.0...v0.7.1) (2019-10-17)
 
 
 ### Bug Fixes


### PR DESCRIPTION
There was a minor issue with patch version releases labeled as an H3 header for changelog. Future changelog headers will always be H2 headers but existing entries must manually be fixed.